### PR TITLE
Removing version constraint on d3m package.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-d3m>=2019.11.10
+d3m
 jsonlines>=1.2.0
 psycopg2-binary>=2.7.5
 # psycopg2>=2.7.5


### PR DESCRIPTION
Not the best thing to do, but it allows us to install these primitives against devel version of the core package as well.

Please resubmit primitive annotations using this, if you approve this change.